### PR TITLE
Remove pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 crytic-compile==0.1.4
-pkg-resources==0.0.0
 prettytable==0.7.2
 pysha3==1.0.2
 slither-analyzer==0.6.7


### PR DESCRIPTION
A [bug in ubuntu](https://github.com/pypa/pip/issues/4022) apparently causes `pip freeze` to write `pkg-resources==0.0.0` into the requirements.txt. This breaks when attempting to install from the file. This PR removes the offending resource.